### PR TITLE
Update link to beginner training pdf

### DIFF
--- a/content/pages/documentation.html
+++ b/content/pages/documentation.html
@@ -14,7 +14,7 @@
                 <h3>Overview and Training Materials</h3>
                 <ul>
                     <li><a href="{filename}/uploads/2016/06/technical-overview-2016-web.pdf">Technical overview</a></li>
-                    <li><a href="https://github.com/irods/irods_training/blob/master/beginner/irods_beginner_training_2019.pdf">iRODS Beginner Training with iRODS 4.2</a></li>
+                    <li><a href="https://github.com/irods/irods_training/blob/main/beginner/irods_beginner_training_2022.pdf">iRODS Beginner Training with iRODS 4.3</a></li>
                     <li><a href="http://www.slides.com/irods">Training Slides</a></li>
                 </ul>
                 <br/>


### PR DESCRIPTION
The link was broken because the training pdf was updated (including a new link).