### PR TITLE
Added support for changing tab titles on different pages of irods.org

### DIFF
--- a/themes/irods_theme/templates/article.html
+++ b/themes/irods_theme/templates/article.html
@@ -3,6 +3,7 @@
   {{ super() }}
   {% if article.description %}
     <meta name="description" content="{{article.description}}" />
+        <title>{{ article.title }}</title>
   {% endif %}
 
   {% for tag in article.tags %}
@@ -12,8 +13,7 @@
 {% endblock %}
 
 {% block content %}
-<title>{{ SITENAME }}</title>
-
+<title>{{ article.title }} - {{ SITENAME }}</title>
 <section class="white_bg">
         <div class="container">
             <div class="space_half"></div>

--- a/themes/irods_theme/templates/article.html
+++ b/themes/irods_theme/templates/article.html
@@ -12,6 +12,8 @@
 {% endblock %}
 
 {% block content %}
+<title>{{ SITENAME }}</title>
+
 <section class="white_bg">
         <div class="container">
             <div class="space_half"></div>

--- a/themes/irods_theme/templates/base.html
+++ b/themes/irods_theme/templates/base.html
@@ -2,7 +2,6 @@
 <html lang="{{ DEFAULT_LANG }}">
 <head>
         {% block head %}
-        <title>{% block title %}{{ SITENAME }}{% endblock title %}</title>
         <meta charset="utf-8" />
         {% if FEED_ALL_ATOM %}
         <link href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Full Atom Feed" />
@@ -36,7 +35,7 @@
         <meta name="description" content="">
         <meta name="author" content="">
 
-        <title>iRODS</title>
+        <!-- <title>iRODS</title> -->
 
         <!-- Bootstrap Core CSS - Uses Bootswatch Flatly Theme: http://bootswatch.com/flatly/ -->
         <link href="{{ SITEURL }}/theme/css/bootstrap.css" rel="stylesheet">

--- a/themes/irods_theme/templates/index.html
+++ b/themes/irods_theme/templates/index.html
@@ -1,3 +1,4 @@
+<title>iRODS</title>
 {% extends "page.html" %}
 {% block content %}
 

--- a/themes/irods_theme/templates/page.html
+++ b/themes/irods_theme/templates/page.html
@@ -9,8 +9,8 @@
 {% endif %}
 
 {% block content %}
+    <title>{% block title %}{{ page.title.title() }} - {{ SITENAME }}{% endblock title %}</title>
 
-    <title>{% block title %}{{ page.title.title() }}{% endblock title %}</title>
     {% if page.title == 'news' %}
         <section class="white_bg">
                 <div class="container">

--- a/themes/irods_theme/templates/page.html
+++ b/themes/irods_theme/templates/page.html
@@ -10,6 +10,7 @@
 
 {% block content %}
 
+    <title>{% block title %}{{ page.title.title() }}{% endblock title %}</title>
     {% if page.title == 'news' %}
         <section class="white_bg">
                 <div class="container">


### PR DESCRIPTION
- only downside right now is that the title tag is no longer located within the head tag. 

pages are named like: `About - iRODS` (for regular pages) and `iRODS Development Update: June 2023 - iRODS` (for articles)